### PR TITLE
Add timeout err handling to identify call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ Drip.prototype.identify = function(identify, fn){
     .type('json')
     .send({ subscribers: [subscriber] })
     .end(function(err, res){
+      if (err && err.timeout) return fn(err);
       if (res.ok) return fn(null, res);
       var errors = res.body.errors || [{}];
       var msg = errors[0].message;


### PR DESCRIPTION
According to our research, the only case where res is undefined is when there's a timeout.
To avoid erroring out on non-timeout calls and therefore losing the custom error handling for non-2xx status codes, we ensure that the error is returned only when `err` and `err.timeout` exist.
