### PR TITLE
Tags and event properties

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -12,6 +12,8 @@ exports.identify = function(msg){
   ret.email = msg.email()
   if (msg.traits()["tags"]) ret.tags = msg.traits()["tags"];
   ret.custom_fields = normalize(msg.traits());
+  delete ret.custom_fields["email"]
+  delete ret.custom_fields["tags"]
   return ret
 };
 
@@ -25,10 +27,12 @@ exports.identify = function(msg){
 
 exports.track = function(msg){
   var ret = {};
-  ret.properties = {};
+  ret.properties = msg.properties() || {};
   if (msg.revenue()) ret.properties.value = Math.round(msg.revenue() * 100);
   ret.action = msg.event();
   ret.email = msg.email();
+  delete ret.properties["email"]
+  delete ret.properties["revenue"]
   return ret;
 };
 
@@ -45,7 +49,7 @@ function normalize(obj){
   var keys = Object.keys(obj);
   return keys.reduce(function(ret, k){
     var key = k.trim().replace(/[^a-z0-9_]/gi, '_');
-    if (key != "email" && key != "tags") ret[key] = obj[k];
+    ret[key] = obj[k];
     return ret;
   }, {});
 };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -9,11 +9,26 @@
 
 exports.identify = function(msg){
   var ret = {}
-  ret.email = msg.email()
-  if (msg.traits()["tags"]) ret.tags = msg.traits()["tags"];
+  ret.email = msg.email();
+  ret.user_id = msg.userId();
+  var topLevelAttributes = [
+    "email",
+    "tags",
+    "new_email",
+    "ip_address",
+    "time_zone",
+    "potential_lead",
+    "prospect"
+  ];
+
   ret.custom_fields = normalize(msg.traits());
-  delete ret.custom_fields["email"]
-  delete ret.custom_fields["tags"]
+
+  for (var i = 0; i < topLevelAttributes.length; i++){
+    var attribute = topLevelAttributes[i]
+    if (msg.traits()[attribute]) ret[attribute] = msg.traits()[attribute];
+    delete ret.custom_fields[attribute];
+  }
+
   return ret
 };
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -8,12 +8,11 @@
  */
 
 exports.identify = function(msg){
-  var traits = normalize(msg.traits());
-
-  return {
-    custom_fields: traits,
-    email: msg.email()
-  };
+  var ret = {}
+  ret.email = msg.email()
+  if (msg.traits()["tags"]) ret.tags = msg.traits()["tags"];
+  ret.custom_fields = normalize(msg.traits());
+  return ret
 };
 
 /**
@@ -46,7 +45,7 @@ function normalize(obj){
   var keys = Object.keys(obj);
   return keys.reduce(function(ret, k){
     var key = k.trim().replace(/[^a-z0-9_]/gi, '_');
-    ret[key] = obj[k];
+    if (key != "email" && key != "tags") ret[key] = obj[k];
     return ret;
   }, {});
 };

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -13,6 +13,7 @@
       "some_trait": true,
       "id": "user-id",
       "trait": true
-    }
+    },
+    "user_id": "user-id"
   }
 }

--- a/test/fixtures/identify-tags.json
+++ b/test/fixtures/identify-tags.json
@@ -6,7 +6,9 @@
       "email": "jd@example.com",
       "trait": true,
       "some trait": true,
-      "tags": ["Tag0", "Tag1"]
+      "tags": ["Tag0", "Tag1"],
+      "time_zone": "America/LosAngeles",
+      "prospect": true
     }
   },
   "output": {
@@ -16,6 +18,9 @@
       "id": "user-id",
       "trait": true
     },
-    "tags": ["Tag0", "Tag1"]
+    "tags": ["Tag0", "Tag1"],
+    "user_id": "user-id",
+    "time_zone": "America/LosAngeles",
+    "prospect": true
   }
 }

--- a/test/fixtures/identify-tags.json
+++ b/test/fixtures/identify-tags.json
@@ -5,14 +5,17 @@
     "traits": {
       "email": "jd@example.com",
       "trait": true,
-      "some trait": true
+      "some trait": true,
+      "tags": ["Tag0", "Tag1"]
     }
   },
-  "output": {    "email": "jd@example.com",
+  "output": {
+    "email": "jd@example.com",
     "custom_fields": {
       "some_trait": true,
       "id": "user-id",
       "trait": true
-    }
+    },
+    "tags": ["Tag0", "Tag1"]
   }
 }

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -10,7 +10,8 @@
     }
   },
   "output": {
-    "properties": { 
+    "properties": {
+      "prop": true,
       "value" : 1999
     },
     "email": "jd@example.com",

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,10 @@ describe('Drip', function(){
       it('should map basic message', function(){
         test.maps('identify-basic');
       });
+
+      it('should map message with tags', function(){
+        test.maps('identify-tags');
+      });
     });
 
     describe('track', function(){
@@ -77,6 +81,7 @@ describe('Drip', function(){
 
       payload.email = msg.email();
       payload.custom_fields = drip.normalize(msg.traits());
+      delete payload.custom_fields["email"]
 
       test
         .set(settings)

--- a/test/index.js
+++ b/test/index.js
@@ -80,8 +80,9 @@ describe('Drip', function(){
       var msg = helpers.identify({ traits: { email: 'amir@segment.io' } });
 
       payload.email = msg.email();
+      payload.user_id = msg.userId();
       payload.custom_fields = drip.normalize(msg.traits());
-      delete payload.custom_fields["email"]
+      delete payload.custom_fields["email"];
 
       test
         .set(settings)


### PR DESCRIPTION
We had a user notice that the server side integration was packing his subscriber tags into into a custom field. Drip's subscribers API accepts a number of top level attributes, including `tags`. This update moves those out of the `custom_fields` object.

It also makes it possible to pass event properties through track calls.
